### PR TITLE
Correct link of zinnia traditional chinese model

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ href="http://macpkg.sourceforge.net/">this site</a>.</p>
 </tr>
 <tr>
 <td>zinnia</td>
-<td><a href="https://github.com/tegaki/tegaki/releases/download/v0.3/tegaki-zinnia-traditional-chinese-light-0.3.zip">Traditional Chinese</a></td>
+<td><a href="https://github.com/tegaki/tegaki/releases/download/v0.3/tegaki-zinnia-traditional-chinese-0.3.zip">Traditional Chinese</a></td>
 <td>&nbsp;</td>
 </tr>
 <tr>


### PR DESCRIPTION
The link of zinnia traditional chinese model is pointing to zinnia traditional chinese (light) model currently. This is to correct the link.